### PR TITLE
Update os_intfs.c

### DIFF
--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -630,7 +630,11 @@ unsigned int rtw_classify8021d(struct sk_buff *skb)
 
 static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
-	, void *accel_priv
+	#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 19, 0)
+		, void *accel_priv
+	#else
+		, struct net_device *sb_dev
+	#endif
 #endif
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
 	, select_queue_fallback_t fallback


### PR DESCRIPTION
The interface of ndo_select_queue callback has changed.
See this commit: torvalds/linux@4f49dec .

Fixes #34 
Fixes #35 